### PR TITLE
Add ProductVariant data layer with AutoMigration 7→8

### DIFF
--- a/app/schemas/com.aisleron.data.AisleronDatabase/8.json
+++ b/app/schemas/com.aisleron.data.AisleronDatabase/8.json
@@ -1,0 +1,475 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "f5cee05cffc55825fcc715aa852d53ef",
+    "entities": [
+      {
+        "tableName": "Aisle",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `locationId` INTEGER NOT NULL, `rank` INTEGER NOT NULL, `isDefault` INTEGER NOT NULL, `expanded` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationId",
+            "columnName": "locationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Location",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `defaultFilter` TEXT NOT NULL, `name` TEXT NOT NULL, `pinned` INTEGER NOT NULL, `showDefaultAisle` INTEGER NOT NULL DEFAULT 1, `noteId` INTEGER, `expanded` INTEGER NOT NULL DEFAULT 1, `rank` INTEGER NOT NULL, FOREIGN KEY(`noteId`) REFERENCES `Note`(`id`) ON UPDATE CASCADE ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultFilter",
+            "columnName": "defaultFilter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showDefaultAisle",
+            "columnName": "showDefaultAisle",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Location_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Location_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Note",
+            "onDelete": "SET NULL",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Product",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `inStock` INTEGER NOT NULL, `qtyNeeded` REAL NOT NULL DEFAULT 0, `noteId` INTEGER, `qtyIncrement` REAL NOT NULL DEFAULT 1, `unitOfMeasure` TEXT NOT NULL DEFAULT '', `trackingMode` TEXT, FOREIGN KEY(`noteId`) REFERENCES `Note`(`id`) ON UPDATE CASCADE ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inStock",
+            "columnName": "inStock",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qtyNeeded",
+            "columnName": "qtyNeeded",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "qtyIncrement",
+            "columnName": "qtyIncrement",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "unitOfMeasure",
+            "columnName": "unitOfMeasure",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "trackingMode",
+            "columnName": "trackingMode",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Product_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Product_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Note",
+            "onDelete": "SET NULL",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AisleProduct",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aisleId` INTEGER NOT NULL, `productId` INTEGER NOT NULL, `rank` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aisleId",
+            "columnName": "aisleId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AisleProduct_aisleId_productId",
+            "unique": true,
+            "columnNames": [
+              "aisleId",
+              "productId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AisleProduct_aisleId_productId` ON `${TABLE_NAME}` (`aisleId`, `productId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LoyaltyCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `intent` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intent",
+            "columnName": "intent",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LocationLoyaltyCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`locationId` INTEGER NOT NULL, `loyaltyCardId` INTEGER NOT NULL, PRIMARY KEY(`locationId`), FOREIGN KEY(`locationId`) REFERENCES `Location`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`loyaltyCardId`) REFERENCES `LoyaltyCard`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "locationId",
+            "columnName": "locationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loyaltyCardId",
+            "columnName": "loyaltyCardId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "locationId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LocationLoyaltyCard_loyaltyCardId",
+            "unique": false,
+            "columnNames": [
+              "loyaltyCardId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocationLoyaltyCard_loyaltyCardId` ON `${TABLE_NAME}` (`loyaltyCardId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Location",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "locationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "LoyaltyCard",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "loyaltyCardId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Note",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `noteText` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "noteText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ProductVariant",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `barcode` TEXT NOT NULL, `createdAt` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`productId`) REFERENCES `Product`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "barcode",
+            "columnName": "barcode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ProductVariant_barcode",
+            "unique": true,
+            "columnNames": [
+              "barcode"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ProductVariant_barcode` ON `${TABLE_NAME}` (`barcode`)"
+          },
+          {
+            "name": "index_ProductVariant_productId",
+            "unique": false,
+            "columnNames": [
+              "productId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ProductVariant_productId` ON `${TABLE_NAME}` (`productId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Product",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "productId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f5cee05cffc55825fcc715aa852d53ef')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/aisleron/data/AisleronTestDatabase.kt
+++ b/app/src/androidTest/java/com/aisleron/data/AisleronTestDatabase.kt
@@ -26,6 +26,7 @@ import com.aisleron.data.maintenance.MaintenanceDao
 import com.aisleron.data.maintenance.MaintenanceDaoTestImpl
 import com.aisleron.data.note.NoteDao
 import com.aisleron.data.product.ProductDao
+import com.aisleron.data.productvariant.ProductVariantDao
 import com.aisleron.testdata.data.aisle.AisleDaoTestImpl
 import com.aisleron.testdata.data.aisleproduct.AisleProductDaoTestImpl
 import com.aisleron.testdata.data.location.LocationDaoTestImpl
@@ -33,6 +34,7 @@ import com.aisleron.testdata.data.loyaltycard.LocationLoyaltyCardDaoTestImpl
 import com.aisleron.testdata.data.loyaltycard.LoyaltyCardDaoTestImpl
 import com.aisleron.testdata.data.note.NoteDaoTestImpl
 import com.aisleron.testdata.data.product.ProductDaoTestImpl
+import com.aisleron.testdata.data.productvariant.ProductVariantDaoTestImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -48,12 +50,15 @@ class AisleronTestDatabase : AisleronDb {
     private val _loyaltyCardDao = LoyaltyCardDaoTestImpl(_locationLoyaltyCardDao)
 
     private val _noteDao = NoteDaoTestImpl()
+    private val _productVariantDao = ProductVariantDaoTestImpl(_productDao)
 
     override fun aisleDao(): AisleDao = _aisleDao
 
     override fun locationDao(): LocationDao = _locationDao
 
     override fun productDao(): ProductDao = _productDao
+
+    override fun productVariantDao(): ProductVariantDao = _productVariantDao
 
     override fun aisleProductDao(): AisleProductDao = _aisleProductDao
 

--- a/app/src/androidTest/java/com/aisleron/data/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/aisleron/data/DatabaseMigrationTest.kt
@@ -253,6 +253,57 @@ class DatabaseMigrationTest {
         }
     }
 
+    private fun populateV7Database(db: SupportSQLiteDatabase) {
+        // Version 7 schema has Location.rank as NOT NULL (no default)
+        // Must include rank in INSERT, unlike earlier versions
+        val locationValues = ContentValues()
+        locationValues.put("type", LocationType.HOME.toString())
+        locationValues.put("defaultFilter", FilterType.NEEDED.toString())
+        locationValues.put("name", "Home")
+        locationValues.put("pinned", false)
+        locationValues.put("rank", 1)  // Required in V7+
+
+        val locationId = db.insert(
+            "Location", android.database.sqlite.SQLiteDatabase.CONFLICT_FAIL, locationValues
+        )
+
+        val aisleValues = ContentValues()
+        aisleValues.put("name", "No Aisle")
+        aisleValues.put("locationId", locationId)
+        aisleValues.put("rank", 1)
+        aisleValues.put("isDefault", true)
+
+        db.insert("Aisle", android.database.sqlite.SQLiteDatabase.CONFLICT_FAIL, aisleValues)
+
+        val productValues = ContentValues()
+        productValues.put("name", "Migration Test Product")
+        productValues.put("inStock", true)
+        productValues.put("qtyNeeded", 10)
+
+        db.insert("Product", android.database.sqlite.SQLiteDatabase.CONFLICT_FAIL, productValues)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate7to8() {
+        helper.createDatabase(testDb, 7).apply {
+            populateV7Database(this)
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(testDb, 8, true)
+
+        db.apply {
+            // Check ProductVariant table exists and has correct schema
+            val queryVariants = SupportSQLiteQueryBuilder.builder("ProductVariant")
+            val cursorVariants: Cursor = query(queryVariants.create())
+            assertEquals(0, cursorVariants.count)
+            cursorVariants.close()
+
+            close()
+        }
+    }
+
     @Test
     @Throws(IOException::class)
     fun migrateAll() = runTest {
@@ -292,6 +343,10 @@ class DatabaseMigrationTest {
         val location = db.locationDao().getLocations().first()
         assertEquals(true, location.expanded)
         assertEquals(location.id, location.rank)
+
+        // ProductVariant introduced in V8
+        val variants = db.productVariantDao().getByProductId(product.id)
+        assertNotNull(variants)
 
         db.close()
     }

--- a/app/src/androidTest/java/com/aisleron/data/productvariant/ProductVariantRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/aisleron/data/productvariant/ProductVariantRepositoryImplTest.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import com.aisleron.data.RepositoryImplTest
+import com.aisleron.data.product.ProductDao
+import com.aisleron.data.product.ProductMapper
+import com.aisleron.data.product.ProductRepositoryImpl
+import com.aisleron.domain.base.BaseRepository
+import com.aisleron.domain.product.Product
+import com.aisleron.domain.product.ProductRepository
+import com.aisleron.domain.productvariant.ProductVariant
+import com.aisleron.domain.productvariant.ProductVariantRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.koin.test.get
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProductVariantRepositoryImplTest : RepositoryImplTest<ProductVariant>() {
+    private val productVariantRepository: ProductVariantRepository get() = repository as ProductVariantRepository
+    private val productRepository: ProductRepository by lazy {
+        ProductRepositoryImpl(
+            productDao = get<ProductDao>(),
+            aisleProductDao = get(),
+            productVariantDao = get<ProductVariantDao>(),
+            productMapper = ProductMapper()
+        )
+    }
+
+    override fun initRepository(): BaseRepository<ProductVariant> =
+        ProductVariantRepositoryImpl(
+            productVariantDao = get<ProductVariantDao>(),
+            productVariantMapper = ProductVariantMapper()
+        )
+
+    private suspend fun getTestProduct(): Product {
+        val product = Product(
+            id = 0,
+            name = "Test Product for Variant",
+            inStock = true,
+            qtyNeeded = 1.0,
+            noteId = null,
+            qtyIncrement = 1.0,
+            trackingMode = com.aisleron.domain.preferences.TrackingMode.DEFAULT,
+            unitOfMeasure = "Qty"
+        )
+        val productId = productRepository.add(product)
+        return productRepository.get(productId)!!
+    }
+
+    override suspend fun getSingleNewItem(): ProductVariant {
+        val product = getTestProduct()
+        return ProductVariant(
+            id = 0,
+            productId = product.id,
+            barcode = "1234567890123",
+            createdAt = System.currentTimeMillis()
+        )
+    }
+
+    override suspend fun getMultipleNewItems(): List<ProductVariant> {
+        val product = getTestProduct()
+        return listOf(
+            ProductVariant(
+                id = 0,
+                productId = product.id,
+                barcode = "1234567890123",
+                createdAt = System.currentTimeMillis()
+            ),
+            ProductVariant(
+                id = 0,
+                productId = product.id,
+                barcode = "9876543210987",
+                createdAt = System.currentTimeMillis() + 1000
+            )
+        )
+    }
+
+    override suspend fun getInvalidItem(): ProductVariant {
+        val product = getTestProduct()
+        return ProductVariant(
+            id = -1,
+            productId = product.id,
+            barcode = "0000000000000",
+            createdAt = System.currentTimeMillis()
+        )
+    }
+
+    override fun getUpdatedItem(item: ProductVariant): ProductVariant =
+        // Use unique barcode based on item id to avoid unique constraint violations
+        item.copy(barcode = "9999999${item.id.toString().padStart(6, '0')}")
+
+    @Test
+    fun getByBarcode_ValidBarcodeProvided_ReturnVariant() = runTest {
+        val variant = getSingleNewItem()
+        val variantId = productVariantRepository.add(variant)
+
+        val foundVariant = productVariantRepository.getByBarcode(variant.barcode).first()
+
+        assertNotNull(foundVariant)
+        assertEquals(variantId, foundVariant.id)
+        assertEquals(variant.barcode, foundVariant.barcode)
+    }
+
+    @Test
+    fun getByBarcode_InvalidBarcodeProvided_ReturnNull() = runTest {
+        val foundVariant = productVariantRepository.getByBarcode("0000000000000").first()
+
+        assertNull(foundVariant)
+    }
+
+    @Test
+    fun getByProductId_ValidProductIdProvided_ReturnVariants() = runTest {
+        val variants = getMultipleNewItems()
+        productVariantRepository.add(variants)
+
+        val foundVariants = productVariantRepository.getByProductId(variants.first().productId).first()
+
+        assertEquals(2, foundVariants.count())
+    }
+
+    @Test
+    fun getByProductId_InvalidProductIdProvided_ReturnEmptyList() = runTest {
+        val foundVariants = productVariantRepository.getByProductId(-1).first()
+
+        assertTrue(foundVariants.isEmpty())
+    }
+
+    @Test
+    fun barcodeExists_ExistingBarcodeProvided_ReturnTrue() = runTest {
+        val variant = getSingleNewItem()
+        productVariantRepository.add(variant)
+
+        val exists = productVariantRepository.barcodeExists(variant.barcode).first()
+
+        assertTrue(exists)
+    }
+
+    @Test
+    fun barcodeExists_NonExistingBarcodeProvided_ReturnFalse() = runTest {
+        val exists = productVariantRepository.barcodeExists("0000000000000").first()
+
+        assertFalse(exists)
+    }
+
+    @Test
+    fun deleteByBarcode_ValidBarcodeProvided_DeleteVariant() = runTest {
+        val variant = getSingleNewItem()
+        productVariantRepository.add(variant)
+        val countBefore = productVariantRepository.getAll().count()
+
+        productVariantRepository.deleteByBarcode(variant.barcode)
+
+        val countAfter = productVariantRepository.getAll().count()
+        assertEquals(countBefore - 1, countAfter)
+
+        val deletedVariant = productVariantRepository.getByBarcode(variant.barcode).first()
+        assertNull(deletedVariant)
+    }
+
+    @Test
+    fun getProductWithBarcode_ValidBarcodeProvided_ReturnProductWithBarcode() = runTest {
+        val variant = getSingleNewItem()
+        productVariantRepository.add(variant)
+
+        val productWithBarcode = productVariantRepository.getProductWithBarcode(variant.barcode).first()
+
+        assertNotNull(productWithBarcode)
+        assertEquals(variant.barcode, productWithBarcode.variant.barcode)
+        assertNotNull(productWithBarcode.product)
+    }
+
+    @Test
+    fun getProductWithBarcode_InvalidBarcodeProvided_ReturnNull() = runTest {
+        val productWithBarcode = productVariantRepository.getProductWithBarcode("0000000000000").first()
+
+        assertNull(productWithBarcode)
+    }
+
+    @Test
+    fun add_TwoVariantsWithSameBarcode_ReplaceExisting() = runTest {
+        val variant = getSingleNewItem()
+        val variantId1 = productVariantRepository.add(variant)
+
+        // Add a new variant with same barcode but different createdAt
+        val updatedVariant = variant.copy(
+            id = 0,
+            createdAt = System.currentTimeMillis() + 5000
+        )
+        val variantId2 = productVariantRepository.add(updatedVariant)
+
+        // Should replace existing, not add new
+        val count = productVariantRepository.getAll().count()
+        assertEquals(1, count)
+
+        // Should have same barcode but potentially updated createdAt
+        val foundVariant = productVariantRepository.getByBarcode(variant.barcode).first()
+        assertNotNull(foundVariant)
+        assertEquals(variant.barcode, foundVariant.barcode)
+    }
+}

--- a/app/src/main/kotlin/com/aisleron/data/AisleronDatabase.kt
+++ b/app/src/main/kotlin/com/aisleron/data/AisleronDatabase.kt
@@ -37,6 +37,8 @@ import com.aisleron.data.note.NoteDao
 import com.aisleron.data.note.NoteEntity
 import com.aisleron.data.product.ProductDao
 import com.aisleron.data.product.ProductEntity
+import com.aisleron.data.productvariant.ProductVariantDao
+import com.aisleron.data.productvariant.ProductVariantEntity
 
 @Database(
     entities = [
@@ -46,16 +48,18 @@ import com.aisleron.data.product.ProductEntity
         AisleProductEntity::class,
         LoyaltyCardEntity::class,
         LocationLoyaltyCardEntity::class,
-        NoteEntity::class
+        NoteEntity::class,
+        ProductVariantEntity::class
     ],
 
-    version = 7,
+    version = 8,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
-        AutoMigration(from = 5, to = 6)
+        AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 7, to = 8)
         /** Migration from 6 to 7 is done manually to set initial rank values [MIGRATION_6_7] */
     ]
 )
@@ -63,6 +67,7 @@ abstract class AisleronDatabase : AisleronDb, RoomDatabase() {
     abstract override fun aisleDao(): AisleDao
     abstract override fun locationDao(): LocationDao
     abstract override fun productDao(): ProductDao
+    abstract override fun productVariantDao(): ProductVariantDao
     abstract override fun aisleProductDao(): AisleProductDao
     abstract override fun maintenanceDao(): MaintenanceDao
     abstract override fun loyaltyCardDao(): LoyaltyCardDao

--- a/app/src/main/kotlin/com/aisleron/data/AisleronDb.kt
+++ b/app/src/main/kotlin/com/aisleron/data/AisleronDb.kt
@@ -25,11 +25,13 @@ import com.aisleron.data.loyaltycard.LoyaltyCardDao
 import com.aisleron.data.maintenance.MaintenanceDao
 import com.aisleron.data.note.NoteDao
 import com.aisleron.data.product.ProductDao
+import com.aisleron.data.productvariant.ProductVariantDao
 
 interface AisleronDb {
     fun aisleDao(): AisleDao
     fun locationDao(): LocationDao
     fun productDao(): ProductDao
+    fun productVariantDao(): ProductVariantDao
     fun aisleProductDao(): AisleProductDao
     fun maintenanceDao(): MaintenanceDao
     fun loyaltyCardDao(): LoyaltyCardDao

--- a/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantDao.kt
+++ b/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantDao.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import com.aisleron.data.base.BaseDao
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ProductVariantDao : BaseDao<ProductVariantEntity> {
+    @Query("SELECT * FROM ProductVariant ORDER BY createdAt ASC")
+    suspend fun getAll(): List<ProductVariantEntity>
+
+    @Query("SELECT * FROM ProductVariant WHERE id = :id")
+    suspend fun getById(id: Int): ProductVariantEntity?
+
+    @Query("SELECT * FROM ProductVariant WHERE barcode = :barcode LIMIT 1")
+    fun getByBarcode(barcode: String): Flow<ProductVariantEntity?>
+
+    @Query("SELECT * FROM ProductVariant WHERE productId = :productId ORDER BY createdAt ASC")
+    fun getByProductId(productId: Int): Flow<List<ProductVariantEntity>>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM ProductVariant WHERE barcode = :barcode LIMIT 1)")
+    fun barcodeExists(barcode: String): Flow<Boolean>
+
+    @Transaction
+    @Query("SELECT * FROM ProductVariant WHERE barcode = :barcode LIMIT 1")
+    fun getProductWithBarcode(barcode: String): Flow<ProductWithBarcode?>
+
+    @Query("DELETE FROM ProductVariant WHERE barcode = :barcode")
+    suspend fun deleteByBarcode(barcode: BarcodeDeleteHelper): Int
+
+    @Query("SELECT DISTINCT productId FROM ProductVariant WHERE productId IN (:productIds)")
+    suspend fun getProductIdsWithVariants(productIds: List<Int>): List<Int>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM ProductVariant WHERE productId = :productId LIMIT 1)")
+    suspend fun hasVariants(productId: Int): Boolean
+
+    @JvmInline
+    value class BarcodeDeleteHelper(val value: String)
+}

--- a/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantEntity.kt
+++ b/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantEntity.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.aisleron.data.product.ProductEntity
+
+@Entity(
+    tableName = "ProductVariant",
+    foreignKeys = [
+        ForeignKey(
+            entity = ProductEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["productId"],
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["barcode"], unique = true),
+        Index(value = ["productId"])
+    ]
+)
+data class ProductVariantEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int,
+    val productId: Int,
+    val barcode: String,
+    @ColumnInfo(defaultValue = "0") val createdAt: Long
+)

--- a/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantMapper.kt
+++ b/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantMapper.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import com.aisleron.data.base.MapperBaseImpl
+import com.aisleron.domain.productvariant.ProductVariant
+
+class ProductVariantMapper : MapperBaseImpl<ProductVariantEntity, ProductVariant>() {
+    override fun toModel(value: ProductVariantEntity) = ProductVariant(
+        id = value.id,
+        productId = value.productId,
+        barcode = value.barcode,
+        createdAt = value.createdAt
+    )
+
+    override fun fromModel(value: ProductVariant) = ProductVariantEntity(
+        id = value.id,
+        productId = value.productId,
+        barcode = value.barcode,
+        createdAt = value.createdAt
+    )
+}

--- a/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/aisleron/data/productvariant/ProductVariantRepositoryImpl.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import com.aisleron.data.base.Mapper
+import com.aisleron.domain.productvariant.ProductVariant
+import com.aisleron.domain.productvariant.ProductVariantRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ProductVariantRepositoryImpl(
+    private val productVariantDao: ProductVariantDao,
+    private val productVariantMapper: Mapper<ProductVariantEntity, ProductVariant>
+) : ProductVariantRepository {
+
+    override suspend fun get(id: Int): ProductVariant? {
+        return productVariantDao.getById(id)?.let { productVariantMapper.toModel(it) }
+    }
+
+    override suspend fun getAll(): List<ProductVariant> {
+        return productVariantMapper.toModelList(productVariantDao.getAll())
+    }
+
+    override suspend fun add(item: ProductVariant): Int {
+        return productVariantDao.upsert(productVariantMapper.fromModel(item)).single().toInt()
+    }
+
+    override suspend fun add(items: List<ProductVariant>): List<Int> {
+        return productVariantDao.upsert(
+            *productVariantMapper.fromModelList(items).toTypedArray()
+        ).map { it.toInt() }
+    }
+
+    override suspend fun update(item: ProductVariant) {
+        productVariantDao.upsert(productVariantMapper.fromModel(item))
+    }
+
+    override suspend fun update(items: List<ProductVariant>) {
+        productVariantDao.upsert(
+            *productVariantMapper.fromModelList(items).toTypedArray()
+        )
+    }
+
+    override suspend fun remove(item: ProductVariant) {
+        productVariantDao.delete(productVariantMapper.fromModel(item))
+    }
+
+    override fun getByBarcode(barcode: String): Flow<ProductVariant?> =
+        productVariantDao.getByBarcode(barcode).map { entity ->
+            entity?.let { productVariantMapper.toModel(it) }
+        }
+
+    override fun getByProductId(productId: Int): Flow<List<ProductVariant>> =
+        productVariantDao.getByProductId(productId).map { entities ->
+            productVariantMapper.toModelList(entities)
+        }
+
+    override fun barcodeExists(barcode: String): Flow<Boolean> = productVariantDao.barcodeExists(barcode)
+
+    override fun getProductWithBarcode(barcode: String): Flow<ProductWithBarcode?> =
+        productVariantDao.getProductWithBarcode(barcode)
+
+    override suspend fun deleteByBarcode(barcode: String) {
+        productVariantDao.deleteByBarcode(
+            ProductVariantDao.BarcodeDeleteHelper(barcode)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/aisleron/data/productvariant/ProductWithBarcode.kt
+++ b/app/src/main/kotlin/com/aisleron/data/productvariant/ProductWithBarcode.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.data.productvariant
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.aisleron.data.product.ProductEntity
+
+data class ProductWithBarcode(
+    @Embedded
+    val variant: ProductVariantEntity,
+
+    @Relation(
+        parentColumn = "productId",
+        entityColumn = "id",
+        entity = ProductEntity::class
+    )
+    val product: ProductEntity
+)

--- a/app/src/main/kotlin/com/aisleron/di/DaoModule.kt
+++ b/app/src/main/kotlin/com/aisleron/di/DaoModule.kt
@@ -25,6 +25,7 @@ import com.aisleron.data.loyaltycard.LocationLoyaltyCardDao
 import com.aisleron.data.loyaltycard.LoyaltyCardDao
 import com.aisleron.data.note.NoteDao
 import com.aisleron.data.product.ProductDao
+import com.aisleron.data.productvariant.ProductVariantDao
 import org.koin.dsl.module
 
 val daoModule = module {
@@ -32,6 +33,7 @@ val daoModule = module {
     single<AisleDao> { get<AisleronDatabase>().aisleDao() }
     single<AisleProductDao> { get<AisleronDatabase>().aisleProductDao() }
     single<ProductDao> { get<AisleronDatabase>().productDao() }
+    single<ProductVariantDao> { get<AisleronDatabase>().productVariantDao() }
     single<LoyaltyCardDao> { get<AisleronDatabase>().loyaltyCardDao() }
     single<LocationLoyaltyCardDao> { get<AisleronDatabase>().locationLoyaltyCardDao() }
     single<NoteDao> { get<AisleronDatabase>().noteDao() }

--- a/app/src/main/kotlin/com/aisleron/domain/productvariant/ProductVariant.kt
+++ b/app/src/main/kotlin/com/aisleron/domain/productvariant/ProductVariant.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.domain.productvariant
+
+import com.aisleron.domain.base.AisleronItem
+
+data class ProductVariant(
+    override val id: Int,
+    val productId: Int,
+    val barcode: String,
+    val createdAt: Long
+) : AisleronItem

--- a/app/src/main/kotlin/com/aisleron/domain/productvariant/ProductVariantRepository.kt
+++ b/app/src/main/kotlin/com/aisleron/domain/productvariant/ProductVariantRepository.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.domain.productvariant
+
+import com.aisleron.data.productvariant.ProductWithBarcode
+import com.aisleron.domain.base.BaseRepository
+import kotlinx.coroutines.flow.Flow
+
+interface ProductVariantRepository : BaseRepository<ProductVariant> {
+    fun getByBarcode(barcode: String): Flow<ProductVariant?>
+    fun getByProductId(productId: Int): Flow<List<ProductVariant>>
+    fun barcodeExists(barcode: String): Flow<Boolean>
+    suspend fun deleteByBarcode(barcode: String)
+    fun getProductWithBarcode(barcode: String): Flow<ProductWithBarcode?>
+}

--- a/testData/src/main/java/com/aisleron/testdata/data/AisleronTestDb.kt
+++ b/testData/src/main/java/com/aisleron/testdata/data/AisleronTestDb.kt
@@ -27,6 +27,7 @@ import com.aisleron.data.loyaltycard.LoyaltyCardDao
 import com.aisleron.data.maintenance.MaintenanceDao
 import com.aisleron.data.note.NoteDao
 import com.aisleron.data.product.ProductDao
+import com.aisleron.data.productvariant.ProductVariantDao
 import com.aisleron.testdata.data.aisle.AisleDaoTestImpl
 import com.aisleron.testdata.data.aisleproduct.AisleProductDaoTestImpl
 import com.aisleron.testdata.data.location.LocationDaoTestImpl
@@ -34,6 +35,7 @@ import com.aisleron.testdata.data.loyaltycard.LocationLoyaltyCardDaoTestImpl
 import com.aisleron.testdata.data.loyaltycard.LoyaltyCardDaoTestImpl
 import com.aisleron.testdata.data.note.NoteDaoTestImpl
 import com.aisleron.testdata.data.product.ProductDaoTestImpl
+import com.aisleron.testdata.data.productvariant.ProductVariantDaoTestImpl
 import kotlinx.coroutines.runBlocking
 
 class AisleronTestDb : AisleronDb {
@@ -44,6 +46,7 @@ class AisleronTestDb : AisleronDb {
     private val _locationLoyaltyCardDao = LocationLoyaltyCardDaoTestImpl()
     private val _loyaltyCardDao = LoyaltyCardDaoTestImpl(_locationLoyaltyCardDao)
     private val _noteDao = NoteDaoTestImpl()
+    private val _productVariantDao = ProductVariantDaoTestImpl(_productDao)
 
     override fun maintenanceDao(): MaintenanceDao {
         TODO("Not yet implemented")
@@ -54,6 +57,8 @@ class AisleronTestDb : AisleronDb {
     override fun locationDao(): LocationDao = _locationDao
 
     override fun productDao(): ProductDao = _productDao
+
+    override fun productVariantDao(): ProductVariantDao = _productVariantDao
 
     override fun aisleProductDao(): AisleProductDao = _aisleProductDao
 

--- a/testData/src/main/java/com/aisleron/testdata/data/productvariant/ProductVariantDaoTestImpl.kt
+++ b/testData/src/main/java/com/aisleron/testdata/data/productvariant/ProductVariantDaoTestImpl.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025-2026 aisleron.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.aisleron.testdata.data.productvariant
+
+import com.aisleron.data.product.ProductDao
+import com.aisleron.data.productvariant.ProductVariantDao
+import com.aisleron.data.productvariant.ProductVariantEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class ProductVariantDaoTestImpl(
+    private val productDao: ProductDao
+) : ProductVariantDao {
+    private val variants = mutableListOf<ProductVariantEntity>()
+
+    override suspend fun getAll(): List<ProductVariantEntity> = variants.toList()
+
+    override suspend fun getById(id: Int): ProductVariantEntity? = variants.find { it.id == id }
+
+    override fun getByBarcode(barcode: String): Flow<ProductVariantEntity?> =
+        flowOf(variants.find { it.barcode == barcode })
+
+    override fun getByProductId(productId: Int): Flow<List<ProductVariantEntity>> =
+        flowOf(variants.filter { it.productId == productId })
+
+    override fun barcodeExists(barcode: String): Flow<Boolean> =
+        flowOf(variants.any { it.barcode == barcode })
+
+    override suspend fun deleteByBarcode(barcode: ProductVariantDao.BarcodeDeleteHelper): Int {
+        val initialSize = variants.size
+        variants.removeAll { it.barcode == barcode.value }
+        return initialSize - variants.size
+    }
+
+    override fun getProductWithBarcode(barcode: String): Flow<com.aisleron.data.productvariant.ProductWithBarcode?> = flowOf(
+        kotlinx.coroutines.runBlocking {
+            val variant = variants.find { it.barcode == barcode } ?: return@runBlocking null
+            val product = productDao.getProduct(variant.productId) ?: return@runBlocking null
+            com.aisleron.data.productvariant.ProductWithBarcode(
+                variant = variant,
+                product = product
+            )
+        }
+    )
+
+    override suspend fun upsert(vararg entity: ProductVariantEntity): List<Long> {
+        val ids = mutableListOf<Long>()
+        entity.forEach { newEntity ->
+            val existingIndex = variants.indexOfFirst { it.id == newEntity.id }
+            if (existingIndex >= 0) {
+                variants[existingIndex] = newEntity
+                ids.add(newEntity.id.toLong())
+            } else {
+                val newId = (variants.maxOfOrNull { it.id } ?: 0) + 1
+                val entityWithId = newEntity.copy(id = newId)
+                variants.add(entityWithId)
+                ids.add(newId.toLong())
+            }
+        }
+        return ids
+    }
+
+    override suspend fun delete(vararg entity: ProductVariantEntity) {
+        entity.forEach { toRemove ->
+            variants.removeAll { it.id == toRemove.id }
+        }
+    }
+
+    override suspend fun getProductIdsWithVariants(productIds: List<Int>): List<Int> =
+        variants.map { it.productId }.distinct().filter { it in productIds }
+
+    override suspend fun hasVariants(productId: Int): Boolean =
+        variants.any { it.productId == productId }
+
+    fun clear() {
+        variants.clear()
+    }
+}


### PR DESCRIPTION
## Description
Add the ProductVariant data layer: entity, DAO, database migration, domain model, repository, mapper, DI registration, and tests. This separates the database changes from the rest of the barcode scanning feature (#139).

- Adds `ProductVariant` table via Room `AutoMigration(from = 7, to = 8)`
- No use cases, UI, or barcode scanning code, pure data/domain layer only

## Related Links
- **Issue:** #139 

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/aisleron/aisleron/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aisleron/aisleron/blob/main/CODE_OF_CONDUCT.md) and agree to abide by their terms.
- [x] I have signed off my commits using `git commit -s`.
- [x] I have included relevant test coverage for these changes.
- [ ] If applicable, I have updated the **automated screenshot runner** to capture new/updated UI states.
- [ ] I have submitted a corresponding Pull Request to the documentation repository.
- [x] I verify that any AI-generated code has been reviewed and tested by me.
- [x] I confirm that no AI-generated images or visual artifacts are included in this PR.
- [ ] I have translated all new/modified strings into all supported languages.

## Visual Changes
None — data layer only.
