### PR TITLE
feat(shopping-list): toggle All Items view from location aisle menu

### DIFF
--- a/app/src/androidTest/java/com/aisleron/ui/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/androidTest/java/com/aisleron/ui/shoppinglist/ShoppingListViewModelTest.kt
@@ -383,9 +383,17 @@ class ShoppingListViewModelTest : KoinTest {
         val locationId = get<LocationRepository>().getAll().first { it.type == LocationType.SHOP }.id
 
         shoppingListViewModel.hydrate(getAisleGrouping(locationId), FilterType.NEEDED, false)
+        val initialState = awaitUiStateUpdated(shoppingListViewModel)
+        assertTrue(initialState.allowAllItemsToggle)
+        assertFalse(initialState.showAllItemsChecked)
 
         shoppingListViewModel.setShowAllItems(true)
         assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)
+        val toggledState = shoppingListViewModel.shoppingListUiState.first {
+            it is ShoppingListViewModel.ShoppingListUiState.Updated &&
+                it.showAllItemsChecked
+        } as ShoppingListViewModel.ShoppingListUiState.Updated
+        assertTrue(toggledState.allowAllItemsToggle)
 
         shoppingListViewModel.submitProductSearch("Ap")
         shoppingListViewModel.requestListRefresh(true)
@@ -398,8 +406,11 @@ class ShoppingListViewModelTest : KoinTest {
         val locationId = get<LocationRepository>().getAll().first { it.type == LocationType.SHOP }.id
 
         shoppingListViewModel.hydrate(getAisleGrouping(locationId), FilterType.ALL, false)
+        val initialState = awaitUiStateUpdated(shoppingListViewModel)
 
         assertFalse(shoppingListViewModel.canShowAllItemsToggle)
+        assertFalse(initialState.allowAllItemsToggle)
+        assertTrue(initialState.showAllItemsChecked)
 
         shoppingListViewModel.setShowAllItems(false)
         assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)

--- a/app/src/androidTest/java/com/aisleron/ui/shoppinglist/ShoppingListViewModelTest.kt
+++ b/app/src/androidTest/java/com/aisleron/ui/shoppinglist/ShoppingListViewModelTest.kt
@@ -379,6 +379,36 @@ class ShoppingListViewModelTest : KoinTest {
     }
 
     @Test
+    fun setShowAllItems_BaseFilterIsNeeded_TogglesFilterWithoutResetOnRefresh() = runTest {
+        val locationId = get<LocationRepository>().getAll().first { it.type == LocationType.SHOP }.id
+
+        shoppingListViewModel.hydrate(getAisleGrouping(locationId), FilterType.NEEDED, false)
+
+        shoppingListViewModel.setShowAllItems(true)
+        assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)
+
+        shoppingListViewModel.submitProductSearch("Ap")
+        shoppingListViewModel.requestListRefresh(true)
+
+        assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)
+    }
+
+    @Test
+    fun setShowAllItems_BaseFilterIsAll_FilterDoesNotChange() = runTest {
+        val locationId = get<LocationRepository>().getAll().first { it.type == LocationType.SHOP }.id
+
+        shoppingListViewModel.hydrate(getAisleGrouping(locationId), FilterType.ALL, false)
+
+        assertFalse(shoppingListViewModel.canShowAllItemsToggle)
+
+        shoppingListViewModel.setShowAllItems(false)
+        assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)
+
+        shoppingListViewModel.setShowAllItems(true)
+        assertEquals(FilterType.ALL, shoppingListViewModel.productFilter)
+    }
+
+    @Test
     fun constructor_NoCoroutineScopeProvided_ShoppingListViewModelReturned() {
         val vm = ShoppingListViewModel(
             shoppingListStreamProviderFactory = get<ShoppingListCoordinatorFactory>()

--- a/app/src/main/kotlin/com/aisleron/domain/shoppinglist/ShoppingListFilter.kt
+++ b/app/src/main/kotlin/com/aisleron/domain/shoppinglist/ShoppingListFilter.kt
@@ -22,5 +22,6 @@ import com.aisleron.domain.FilterType
 data class ShoppingListFilter(
     val productFilter: FilterType,
     val productNameQuery: String = "",
-    val showEmptyAisles: Boolean = false
+    val showEmptyAisles: Boolean = false,
+    val allowAllItemsToggle: Boolean = false
 )

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
@@ -373,7 +373,7 @@ class ShoppingListFragment(
         editShopMenuItem?.isVisible = currentState?.showEditShop ?: false
         loyaltyCardMenuItem?.isVisible = currentState?.showLoyaltyCard ?: false
         showAllItemsMenuItem?.apply {
-            isVisible = currentState?.showAllItemsToggle ?: false
+            isVisible = currentState?.allowAllItemsToggle ?: false
             isChecked = currentState?.showAllItemsChecked ?: false
         }
     }

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
@@ -41,6 +41,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.aisleron.R
+import com.aisleron.domain.FilterType
 import com.aisleron.domain.base.AisleronException
 import com.aisleron.domain.loyaltycard.LoyaltyCard
 import com.aisleron.ui.AisleronExceptionMap
@@ -88,6 +89,7 @@ class ShoppingListFragment(
     private var actionMode: ActionMode? = null
     private var loyaltyCardMenuItem: MenuItem? = null
     private var editShopMenuItem: MenuItem? = null
+    private var showAllItemsMenuItem: MenuItem? = null
 
     private val showEmptyAisles: Boolean
         get() = shoppingListPreferences.showEmptyAisles()
@@ -164,9 +166,10 @@ class ShoppingListFragment(
                                     updateTitle(it.title)
                                     setMenuItemVisibility()
 
-                                    (view.adapter as ShoppingListItemRecyclerViewAdapter).submitList(
-                                        it.shoppingList
-                                    )
+                                    (view.adapter as ShoppingListItemRecyclerViewAdapter).apply {
+                                        updateListFilter(shoppingListViewModel.productFilter)
+                                        submitList(it.shoppingList)
+                                    }
 
                                     initializeFab(it.manageAisles)
                                     initializeActionMode(
@@ -333,6 +336,7 @@ class ShoppingListFragment(
     override fun onDestroyView() {
         searchView?.removeOnAttachStateChangeListener(searchViewListener)
         searchView = null
+        showAllItemsMenuItem = null
         fabHandler.reset()
         super.onDestroyView()
     }
@@ -370,6 +374,11 @@ class ShoppingListFragment(
 
         editShopMenuItem?.isVisible = currentState?.showEditShop ?: false
         loyaltyCardMenuItem?.isVisible = currentState?.showLoyaltyCard ?: false
+        showAllItemsMenuItem?.apply {
+            isVisible =
+                (currentState?.showEditShop ?: false) && shoppingListViewModel.canShowAllItemsToggle
+            isChecked = shoppingListViewModel.productFilter == FilterType.ALL
+        }
     }
 
     private fun displayStatusChangeSnackBar(item: ProductShoppingListItem, inStock: Boolean) {
@@ -626,6 +635,9 @@ class ShoppingListFragment(
         searchView?.addOnAttachStateChangeListener(searchViewListener)
 
         menu.findItem(R.id.mnu_show_empty_aisles).apply { isChecked = showEmptyAisles }
+        showAllItemsMenuItem = menu.findItem(R.id.mnu_show_all_items).apply {
+            isChecked = shoppingListViewModel.productFilter == FilterType.ALL
+        }
 
         editShopMenuItem = menu.findItem(R.id.mnu_edit_shop)
         loyaltyCardMenuItem = menu.findItem(R.id.mnu_show_loyalty_card)
@@ -655,6 +667,13 @@ class ShoppingListFragment(
                 shoppingListPreferences.setShowEmptyAisles(newValue)
                 menuItem.isChecked = newValue
                 shoppingListViewModel.setShowEmptyAisles(newValue)
+                true
+            }
+
+            R.id.mnu_show_all_items -> {
+                val newValue = shoppingListViewModel.productFilter != FilterType.ALL
+                menuItem.isChecked = newValue
+                shoppingListViewModel.setShowAllItems(newValue)
                 true
             }
 

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListFragment.kt
@@ -41,7 +41,6 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.aisleron.R
-import com.aisleron.domain.FilterType
 import com.aisleron.domain.base.AisleronException
 import com.aisleron.domain.loyaltycard.LoyaltyCard
 import com.aisleron.ui.AisleronExceptionMap
@@ -166,10 +165,9 @@ class ShoppingListFragment(
                                     updateTitle(it.title)
                                     setMenuItemVisibility()
 
-                                    (view.adapter as ShoppingListItemRecyclerViewAdapter).apply {
-                                        updateListFilter(shoppingListViewModel.productFilter)
-                                        submitList(it.shoppingList)
-                                    }
+                                    (view.adapter as ShoppingListItemRecyclerViewAdapter).submitList(
+                                        it.shoppingList
+                                    )
 
                                     initializeFab(it.manageAisles)
                                     initializeActionMode(
@@ -375,9 +373,8 @@ class ShoppingListFragment(
         editShopMenuItem?.isVisible = currentState?.showEditShop ?: false
         loyaltyCardMenuItem?.isVisible = currentState?.showLoyaltyCard ?: false
         showAllItemsMenuItem?.apply {
-            isVisible =
-                (currentState?.showEditShop ?: false) && shoppingListViewModel.canShowAllItemsToggle
-            isChecked = shoppingListViewModel.productFilter == FilterType.ALL
+            isVisible = currentState?.showAllItemsToggle ?: false
+            isChecked = currentState?.showAllItemsChecked ?: false
         }
     }
 
@@ -635,9 +632,7 @@ class ShoppingListFragment(
         searchView?.addOnAttachStateChangeListener(searchViewListener)
 
         menu.findItem(R.id.mnu_show_empty_aisles).apply { isChecked = showEmptyAisles }
-        showAllItemsMenuItem = menu.findItem(R.id.mnu_show_all_items).apply {
-            isChecked = shoppingListViewModel.productFilter == FilterType.ALL
-        }
+        showAllItemsMenuItem = menu.findItem(R.id.mnu_show_all_items)
 
         editShopMenuItem = menu.findItem(R.id.mnu_edit_shop)
         loyaltyCardMenuItem = menu.findItem(R.id.mnu_show_loyalty_card)
@@ -671,7 +666,7 @@ class ShoppingListFragment(
             }
 
             R.id.mnu_show_all_items -> {
-                val newValue = shoppingListViewModel.productFilter != FilterType.ALL
+                val newValue = !menuItem.isChecked
                 menuItem.isChecked = newValue
                 shoppingListViewModel.setShowAllItems(newValue)
                 true

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListItemRecyclerViewAdapter.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListItemRecyclerViewAdapter.kt
@@ -59,7 +59,7 @@ class ShoppingListItemRecyclerViewAdapter(
     private val listener: ShoppingListItemListener,
     private val defaultTrackingMode: TrackingMode,
     private val defaultUnitOfMeasure: String,
-    private val listFilter: FilterType,
+    private var listFilter: FilterType,
     private val noteHint: NoteHint
 ) : ListAdapter<ShoppingListItem, ViewHolder>(ShoppingListItemDiffCallback()),
     ShoppingListItemMoveCallbackListener.Listener {
@@ -68,6 +68,13 @@ class ShoppingListItemRecyclerViewAdapter(
     private var longClicked = false
     private var dragStarted = false
     private var itemMoved: Boolean = false
+
+    fun updateListFilter(listFilter: FilterType) {
+        if (this.listFilter == listFilter) return
+
+        this.listFilter = listFilter
+        notifyItemRangeChanged(0, itemCount)
+    }
 
     class ShoppingListItemDiffCallback : DiffUtil.ItemCallback<ShoppingListItem>() {
         override fun areItemsTheSame(

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListItemRecyclerViewAdapter.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListItemRecyclerViewAdapter.kt
@@ -59,7 +59,7 @@ class ShoppingListItemRecyclerViewAdapter(
     private val listener: ShoppingListItemListener,
     private val defaultTrackingMode: TrackingMode,
     private val defaultUnitOfMeasure: String,
-    private var listFilter: FilterType,
+    private val listFilter: FilterType,
     private val noteHint: NoteHint
 ) : ListAdapter<ShoppingListItem, ViewHolder>(ShoppingListItemDiffCallback()),
     ShoppingListItemMoveCallbackListener.Listener {
@@ -68,13 +68,6 @@ class ShoppingListItemRecyclerViewAdapter(
     private var longClicked = false
     private var dragStarted = false
     private var itemMoved: Boolean = false
-
-    fun updateListFilter(listFilter: FilterType) {
-        if (this.listFilter == listFilter) return
-
-        this.listFilter = listFilter
-        notifyItemRangeChanged(0, itemCount)
-    }
 
     class ShoppingListItemDiffCallback : DiffUtil.ItemCallback<ShoppingListItem>() {
         override fun areItemsTheSame(

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
@@ -61,8 +61,11 @@ class ShoppingListViewModel(
     private val coroutineScope = coroutineScopeProvider ?: this.viewModelScope
     private var hydrated = false
     private var _showEmptyAisles: Boolean = true
+    private var baseProductFilter: FilterType = FilterType.NEEDED
     val productFilter: FilterType
         get() = _shoppingListFilters.value?.productFilter ?: FilterType.NEEDED
+    val canShowAllItemsToggle: Boolean
+        get() = baseProductFilter != FilterType.ALL
 
     private val _aislesForLocation = MutableStateFlow<List<AisleListEntry>>(emptyList())
     val aislesForLocation: StateFlow<List<AisleListEntry>> = _aislesForLocation
@@ -157,6 +160,7 @@ class ShoppingListViewModel(
 
         shoppingListCoordinator = shoppingListStreamProviderFactory.create(listGrouping)
         _showEmptyAisles = showEmptyAisles
+        baseProductFilter = productFilter
 
         _shoppingListFilters.value = ShoppingListFilter(
             productFilter = productFilter,
@@ -222,6 +226,14 @@ class ShoppingListViewModel(
 
         _showEmptyAisles = showEmptyAisles
         _shoppingListFilters.update { it?.copy(showEmptyAisles = _showEmptyAisles) }
+    }
+
+    fun setShowAllItems(showAllItems: Boolean) {
+        if (!canShowAllItemsToggle) return
+        val newFilter = if (showAllItems) FilterType.ALL else baseProductFilter
+        if (productFilter == newFilter) return
+
+        _shoppingListFilters.update { it?.copy(productFilter = newFilter) }
     }
 
     fun requestListRefresh(returnDefaultList: Boolean) {

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
@@ -112,7 +112,7 @@ class ShoppingListViewModel(
                     .map { state ->
                         when (state) {
                             is ShoppingListUiState.Updated -> state.copy(
-                                showAllItemsToggle =
+                                allowAllItemsToggle =
                                     state.showEditShop && baseProductFilter != FilterType.ALL,
                                 showAllItemsChecked = filters.productFilter == FilterType.ALL
                             )
@@ -425,7 +425,7 @@ class ShoppingListViewModel(
             val showEditShop: Boolean,
             val manageAisles: Boolean,
             val showLoyaltyCard: Boolean,
-            val showAllItemsToggle: Boolean = false,
+            val allowAllItemsToggle: Boolean = false,
             val showAllItemsChecked: Boolean = false
         ) : ShoppingListUiState()
     }

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -108,6 +109,17 @@ class ShoppingListViewModel(
 
             shoppingListCoordinator?.let {
                 it.getShoppingListState(combinedFilter, selections)
+                    .map { state ->
+                        when (state) {
+                            is ShoppingListUiState.Updated -> state.copy(
+                                showAllItemsToggle =
+                                    state.showEditShop && baseProductFilter != FilterType.ALL,
+                                showAllItemsChecked = filters.productFilter == FilterType.ALL
+                            )
+
+                            else -> state
+                        }
+                    }
                     .onStart { emit(ShoppingListUiState.Loading) }
                     .catch { e ->
                         emit(mapToErrorState(e))
@@ -412,7 +424,9 @@ class ShoppingListViewModel(
             val title: ListTitle,
             val showEditShop: Boolean,
             val manageAisles: Boolean,
-            val showLoyaltyCard: Boolean
+            val showLoyaltyCard: Boolean,
+            val showAllItemsToggle: Boolean = false,
+            val showAllItemsChecked: Boolean = false
         ) : ShoppingListUiState()
     }
 

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/ShoppingListViewModel.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -62,11 +61,11 @@ class ShoppingListViewModel(
     private val coroutineScope = coroutineScopeProvider ?: this.viewModelScope
     private var hydrated = false
     private var _showEmptyAisles: Boolean = true
-    private var baseProductFilter: FilterType = FilterType.NEEDED
+    private var initialProductFilter: FilterType = FilterType.NEEDED
     val productFilter: FilterType
         get() = _shoppingListFilters.value?.productFilter ?: FilterType.NEEDED
     val canShowAllItemsToggle: Boolean
-        get() = baseProductFilter != FilterType.ALL
+        get() = _shoppingListFilters.value?.allowAllItemsToggle ?: true
 
     private val _aislesForLocation = MutableStateFlow<List<AisleListEntry>>(emptyList())
     val aislesForLocation: StateFlow<List<AisleListEntry>> = _aislesForLocation
@@ -109,17 +108,6 @@ class ShoppingListViewModel(
 
             shoppingListCoordinator?.let {
                 it.getShoppingListState(combinedFilter, selections)
-                    .map { state ->
-                        when (state) {
-                            is ShoppingListUiState.Updated -> state.copy(
-                                allowAllItemsToggle =
-                                    state.showEditShop && baseProductFilter != FilterType.ALL,
-                                showAllItemsChecked = filters.productFilter == FilterType.ALL
-                            )
-
-                            else -> state
-                        }
-                    }
                     .onStart { emit(ShoppingListUiState.Loading) }
                     .catch { e ->
                         emit(mapToErrorState(e))
@@ -172,11 +160,12 @@ class ShoppingListViewModel(
 
         shoppingListCoordinator = shoppingListStreamProviderFactory.create(listGrouping)
         _showEmptyAisles = showEmptyAisles
-        baseProductFilter = productFilter
+        initialProductFilter = productFilter
 
         _shoppingListFilters.value = ShoppingListFilter(
             productFilter = productFilter,
-            showEmptyAisles = _showEmptyAisles
+            showEmptyAisles = _showEmptyAisles,
+            allowAllItemsToggle = productFilter != FilterType.ALL
         )
 
         hydrated = true
@@ -242,7 +231,7 @@ class ShoppingListViewModel(
 
     fun setShowAllItems(showAllItems: Boolean) {
         if (!canShowAllItemsToggle) return
-        val newFilter = if (showAllItems) FilterType.ALL else baseProductFilter
+        val newFilter = if (showAllItems) FilterType.ALL else initialProductFilter
         if (productFilter == newFilter) return
 
         _shoppingListFilters.update { it?.copy(productFilter = newFilter) }

--- a/app/src/main/kotlin/com/aisleron/ui/shoppinglist/coordinator/AisleListCoordinator.kt
+++ b/app/src/main/kotlin/com/aisleron/ui/shoppinglist/coordinator/AisleListCoordinator.kt
@@ -57,7 +57,10 @@ class AisleListCoordinator(
                 title = getListTitle(collectedLocation, filters.productFilter),
                 showEditShop = collectedLocation?.type == LocationType.SHOP,
                 manageAisles = true,
-                showLoyaltyCard = getLoyaltyCardForLocationUseCase(locationId) != null
+                showLoyaltyCard = getLoyaltyCardForLocationUseCase(locationId) != null,
+                allowAllItemsToggle = filters.allowAllItemsToggle &&
+                    collectedLocation?.type == LocationType.SHOP,
+                showAllItemsChecked = filters.productFilter == FilterType.ALL
             )
 
             state

--- a/app/src/main/res/menu/shopping_list_fragment_main.xml
+++ b/app/src/main/res/menu/shopping_list_fragment_main.xml
@@ -55,6 +55,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/mnu_show_all_items"
+        android:title="@string/menu_all_items"
+        android:checkable="true"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/mnu_expand_collapse_aisles"
         android:title="@string/expand_collapse_aisles"
         app:showAsAction="never" />


### PR DESCRIPTION
## Description
Add an `All Items` toggle to shop/location-specific aisle-grouped shopping lists. The toggle switches between the list's base filter and `All Items`, and is hidden when the current list is already based on `All Items`.

This is partially related to #90, but does not implement #90 itself. It adds a way to toggle "All items" and "Needed" in a menu-based way to temporarily view all items from a location list only.

## Related Links
- **Documentation PR:** N/A for now
- **Issue:** Related to #90

## Testing
- Before this change, the local instrumentation baseline was already not stable run-to-run on my test device. The exact failing set varied between runs because several tests are timing-sensitive.
- After this change, I ran the same suite again. The instrumentation results remained in the same unstable range, and the failure pattern still varied between runs.
- I verified the feature-specific behavior for this PR and included relevant test coverage.

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/aisleron/aisleron/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aisleron/aisleron/blob/main/CODE_OF_CONDUCT.md) and agree to abide by their terms.
- [x] I have signed off my commits using `git commit -s`.
- [x] I have included relevant test coverage for these changes.
- [ ] If applicable, I have updated the **automated screenshot runner** to capture new/updated UI states.
- [ ] I have submitted a corresponding Pull Request to the documentation repository.
- [x] I verify that any AI-generated code has been reviewed and tested by me.
- [x] I confirm that no AI-generated images or visual artifacts are included in this PR.
- [ ] I have translated all new/modified strings into all supported languages.

## Visual Changes
Attached screenshot showing the new `All Items` overflow menu toggle in a shop/location-specific aisle list.
<img width="386" height="338" alt="image" src="https://github.com/user-attachments/assets/167b4167-be9b-472e-9c2c-8c2dba525836" />

## Notes
- This PR does not implement swipe navigation between `Needed` and `All Items`.
- This PR is scoped to shop/location-specific aisle-grouped lists only.
- The UI uses the existing `All Items` string resource; no new translatable strings were added.
- Docs need a small update, likely in `product-list.md`, to mention that a shop/location-specific list can be temporarily switched to `All Items` from the overflow menu.
- I will open the docs PR if this feature PR looks like a fit for the project.